### PR TITLE
Update for fastmech=0.4.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,6 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# CSDMS componenentizing
+pymt_fastmech/lib/fastmech.c

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ install:
 - source activate _testing
 - conda install -q conda-build anaconda-client
 - conda install -q --file=requirements.txt
+- conda install -q gfortran_$TRAVIS_OS_NAME-64
 - conda install -q bmi-tester model_metadata
 script:
 - python setup.py develop

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
 - conda create -n _testing python=$TRAVIS_PYTHON_VERSION
 - source activate _testing
 - conda install -q conda-build anaconda-client
-- conda install -q --file=requirements.txt
+- conda install -q --file=requirements.txt -c csdms-stack
 - conda install -q gfortran_$TRAVIS_OS_NAME-64
 - conda install -q bmi-tester model_metadata
 script:

--- a/meta/FaSTMECH/fastmech.cfg
+++ b/meta/FaSTMECH/fastmech.cfg
@@ -177,22 +177,22 @@
 
 [2d_solution_output]
     # Output velocity (streamwise and normal relative to grid): (F) no; (T) yes:
-    velocitysn = {{2d_solution_output__velocitysn}}
+    velocitysn = {{twod_solution_output__velocitysn}}
 
     # Output boundary shear stress: (F) no; (T) yes:
-    shearstressxy = {{2d_solution_output__shearstressxy}}
+    shearstressxy = {{twod_solution_output__shearstressxy}}
 
     # Output boundary shear stress (streamwise and normal relative to grid): (F) no; (T) yes:
-    shearstresssn = {{2d_solution_output__shearstresssn}}
+    shearstresssn = {{twod_solution_output__shearstresssn}}
 
     # Output drag coefficient: (F) no; (T) yes:
-    cd = {{2d_solution_output__cd}}
+    cd = {{twod_solution_output__cd}}
 
     # Output area associated with each node (usefull when calculating habitat params): (F) no; (T) yes:
-    area = {{2d_solution_output__area}}
+    area = {{twod_solution_output__area}}
 
     # Output unit discharge: (F) no; (T) yes:
-    unit_discharge = {{2d_solution_output__unit_discharge}}
+    unit_discharge = {{twod_solution_output__unit_discharge}}
 
 [quasi3d_solution]
     # Calculate quasi-three-dimensional solution: (0) no; (1) yes:

--- a/meta/FaSTMECH/fastmech.cfg
+++ b/meta/FaSTMECH/fastmech.cfg
@@ -127,7 +127,7 @@
     iter_stop_checking = {{iter_stop_checking}}
 
 [solution_parameters]
-    # Solution type: (0) constant discharge; (1) time-varying discharge:
+    # Solution type: (0) constant discharge; (1) time-varying discharge; (3) set at runtime:
     solution_type = {{solution_type}}
 
     # Number of initial iterations:

--- a/meta/FaSTMECH/fastmech.cfg
+++ b/meta/FaSTMECH/fastmech.cfg
@@ -1,233 +1,233 @@
 [CGNSFile]
     # Use iRIC produced .cgns file: (0) no; (1) all; (2) grid only:
-    use_cgn = {{use_cgn}}
+    use_cgn = {{CGNSFile__use_cgn}}
 
     # if use_cgn == 1 or 2: path and filename of .cgns file:
-    cgnsfile = {{cgnsfile}}
+    cgnsfile = {{CGNSFile__cgnsfile}}
 
 [Discharge]
     # Discharge Type (Enumeration): (0) Single valued, (1) Variable:
-    discharge_type = {{discharge_type}}
+    discharge_type = {{Discharge__discharge_type}}
 
     # Single valued discharge (m^3/s):
-    discharge = {{discharge}}
+    discharge = {{Discharge__discharge}}
 
     # Velocity depth weighting coefficient:
-    vdc = {{vdc}}
+    vdc = {{Discharge__vdc}}
 
     # Velocity angle relative to boundary (degrees):
-    vac = {{vac}}
+    vac = {{Discharge__vac}}
 
     # If discharge_type == 1: Discharge array (m^3/s):
-    vvalue = {{vvalue}}
+    vvalue = {{Discharge__vvalue}}
 
     # If discharge_type == 1:Time array (s):
-    vparam = {{vparam}}
+    vparam = {{Discharge__vparam}}
 
 [Stage]
     # Stage type (Enumeration): (0) single valued, (1) time-series, (2) rating-curve:
-    stage_type = {{stage_type}}
+    stage_type = {{Stage__stage_type}}
 
     # If stage_type == 0: Single valued Stage (m):
-    stage = {{stage}}
+    stage = {{Stage__stage}}
 
     # If stage_type == 1 or 2: Stage Value(Stage type): (1) stage (m); (2) stage (m); array:
-    svalue = {{svalue}}
+    svalue = {{Stage__svalue}}
 
     # If stage_type == 1 or 2: Stage Param(Stage type): (1) time (s); (2) discharge (m^3/s); array):
-    sparam = {{sparam}}
+    sparam = {{Stage__sparam}}
 
 [Roughness]
     # Roughness type: (0) drag Coefficient; (1) znaught:
-    roughness_type = {{roughness_type}}
+    roughness_type = {{Roughness__roughness_type}}
 
     # Distribution type: (0) single valued; (1) spatially distributed:
-    distribution_type = {{distribution_type}}
+    distribution_type = {{Roughness__distribution_type}}
 
     # If roughness_type == 0: single value of roughness(roughness type): (0) Cd; (1) znaught:
-    roughness = {{roughness}}
+    roughness = {{Roughness__roughness}}
 
     # If roughness_type == 1: Cd max value(roughness type): (0) Cd; (1) znaught:
-    cdmin = {{cdmin}}
+    cdmin = {{Roughness__cdmin}}
 
     # If roughness_type == 1: Cd min value(roughness type): (0) Cd; (1) znaught:
-    cdmax = {{cdmax}}
+    cdmax = {{Roughness__cdmax}}
 
 [Lateral_eddy_viscosity]
     # Lateral Eddy Viscosity (LEV) type: (0) single valued; (1) varialble over iteration:
-    lev_type = {{lev_type}}
+    lev_type = {{Lateral_eddy_viscosity__lev_type}}
 
     # If lev_type == 1: Iteration to begin change:
-    start_iteration = {{start_iteration}}
+    start_iteration = {{Lateral_eddy_viscosity__start_iteration}}
 
     # If lev_type == 1: Iteration to end change:
-    end_iteration = {{end_iteration}}
+    end_iteration = {{Lateral_eddy_viscosity__end_iteration}}
 
     # If lev_type == 1: Starting value of LEV. Begins to change at start_iteration:
-    start_value = {{start_value}}
+    start_value = {{Lateral_eddy_viscosity__start_value}}
 
     # If lev_typee == 1: Ending value of LEV. Value at end_iteration:
-    end_value = {{end_value}}
+    end_value = {{Lateral_eddy_viscosity__end_value}}
 
     # If lev_type == 0: Single value of LEV:
-    lev = {{lev}}
+    lev = {{Lateral_eddy_viscosity__lev}}
 
 [Grid_extension]
     # Number of streamwise nodes to extend grid at downstream boundary:
-    ext_numnodes = {{ext_numnodes}}
+    ext_numnodes = {{Grid_extension__ext_numnodes}}
 
     # if ext_numnodes > 0: slope to extend downstream boundary elevation:
-    ext_slope = {{ext_slope}}
+    ext_slope = {{Grid_extension__ext_slope}}
 
     # Condition of velocity at downstream boundary: (0) normal; (1) force no-recirculation:
-    down_stream_boundary = {{down_stream_boundary}}
+    down_stream_boundary = {{Grid_extension__down_stream_boundary}}
 
 [initial_wse_conditions]
     # Initial water-surface elevation (wse) type: (0) upstream-stage; (1) uniform-slope; (2) 1d step-backwater; (3) hot start:
-    init_wse_type = {{init_wse_type}}
+    init_wse_type = {{initial_wse_conditions__init_wse_type}}
 
     # If init_wse_type == 0: upstream-stage value (m):
-    upstream_stage =  {{upstream_stage}}
+    upstream_stage =  {{initial_wse_conditions__upstream_stage}}
 
     # If init_wse_type == 1: uniform slope  value (m/m):
-    uniform_slope = {{uniform_slope}}
+    uniform_slope = {{initial_wse_conditions__uniform_slope}}
 
     # If init_wse_type == 2: Cd for 1d step-backwater value (Cd):
-    oned_cd = {{oned_cd}}
+    oned_cd = {{initial_wse_conditions__oned_cd}}
 
     # Output hot-start files: (0) no; (1) yes:
-    hs_output = {{hs_output}}
+    hs_output = {{initial_wse_conditions__hs_output}}
 
     # If Output hot-start files == 1: path/to/hotstartfile/:
-    hs_file_path = {{hs_file_path}}
+    hs_file_path = {{initial_wse_conditions__hs_file_path}}
 
     # If Output hot-start files == 1: time to write hot-start file:
-    hs_times = {{hs_times}}
+    hs_times = {{initial_wse_conditions__hs_times}}
 
     # If hs_output == 1: hotstart filename:
-    hs_file = {{hs_file}}
+    hs_file = {{initial_wse_conditions__hs_file}}
 
 [wetting_and_drying]
     # Drying type: (0) set node off; (1) set node to drying depth:
-    drying_type = {{drying_type}}
+    drying_type = {{wetting_and_drying__drying_type}}
 
     # Drying depth (typically 0.0) (m):
-    drying_depth = {{drying_depth}}
+    drying_depth = {{wetting_and_drying__drying_depth}}
 
     # Calculate rewetting: (F) No; (T) yes:
-    calc_rewetting = {{calc_rewetting}}
+    calc_rewetting = {{wetting_and_drying__calc_rewetting}}
 
     # If calc_rewetting == 1: Rewetting depth (typically 0.015) (m):
-    rewetting_depth = {{rewetting_depth}}
+    rewetting_depth = {{wetting_and_drying__rewetting_depth}}
 
     # If calc_rewetting == 1: Iteration interval to check rewetting:
-    check_rewetting_iter = {{check_rewetting_iter}}
+    check_rewetting_iter = {{wetting_and_drying__check_rewetting_iter}}
 
     # If calc_rewetting == 1: Iteration to stop check rewetting:
-    iter_stop_checking = {{iter_stop_checking}}
+    iter_stop_checking = {{wetting_and_drying__iter_stop_checking}}
 
 [solution_parameters]
     # Solution type: (0) constant discharge; (1) time-varying discharge; (3) set at runtime:
-    solution_type = {{solution_type}}
+    solution_type = {{solution_parameters__solution_type}}
 
     # Number of initial iterations:
-    num_iterations = {{num_iterations}}
+    num_iterations = {{solution_parameters__num_iterations}}
 
     # Write solution during initial iteration: (F) no (typical) (T) yes:
-    iter_solution_out = {{iter_solution_out}}
+    iter_solution_out = {{solution_parameters__iter_solution_out}}
 
     # If iter_sol_out == 1: iteration interval to write solution:
-    iter_solution_inc = {{iter_solution_inc}}
+    iter_solution_inc = {{solution_parameters__iter_solution_inc}}
 
     # If solution_type == 1: start time (s):
-    start_time = {{start_time}}
+    start_time = {{solution_parameters__start_time}}
 
     # If solution_type == 1: end time (s):
-    end_time = {{end_time}}
+    end_time = {{solution_parameters__end_time}}
 
     # If solution_type == 1: time-step (s):
-    time_step = {{time_step}}
+    time_step = {{solution_parameters__time_step}}
 
     # If solution_type == 1: iteration between time-steps:
-    time_step_iter = {{time_step_iter}} 
+    time_step_iter = {{solution_parameters__time_step_iter}} 
 
     # If solution_type == 1: time-step increment to save solution (s):
-    plot_inc = {{plot_inc}}
+    plot_inc = {{solution_parameters__plot_inc}}
 
     # If solution_type == 1: multiplyer of iteration between time-steps (increases time_step_iter if a large number of nodes become dry or wet):
-    iter_multiplyer = {{iter_multiplyer}}
+    iter_multiplyer = {{solution_parameters__iter_multiplyer}}
 
     # Stop and write solution for debugging: (0) no; (1) yes:
-    debug_stop = {{debug_stop}}
+    debug_stop = {{solution_parameters__debug_stop}}
 
     # If debug_stop == 1: time-step to stop solution:
-    debug_time_step = {{debug_time_step}}
+    debug_time_step = {{solution_parameters__debug_time_step}}
 
     # If debug_stop == 1: iteration to stop solution at debug_time_step:
-    debug_iteration = {{debug_iteration}}
+    debug_iteration = {{solution_parameters__debug_iteration}}
 
     # WSE relaxation coefficient:
-    erelax = {{erelax}}
+    erelax = {{solution_parameters__erelax}}
 
     # Velocity relaxation coefficient:
-    urelax = {{urelax}}
+    urelax = {{solution_parameters__urelax}}
 
     # Slope relaxation coefficient:
-    arelax = {{arelax}}
+    arelax = {{solution_parameters__arelax}}
 
 [2d_solution_output]
     # Output velocity (streamwise and normal relative to grid): (F) no; (T) yes:
-    velocitysn = {{velocitysn}}
+    velocitysn = {{2d_solution_output__velocitysn}}
 
     # Output boundary shear stress: (F) no; (T) yes:
-    shearstressxy = {{shearstressxy}}
+    shearstressxy = {{2d_solution_output__shearstressxy}}
 
     # Output boundary shear stress (streamwise and normal relative to grid): (F) no; (T) yes:
-    shearstresssn = {{shearstresssn}}
+    shearstresssn = {{2d_solution_output__shearstresssn}}
 
     # Output drag coefficient: (F) no; (T) yes:
-    cd = {{cd}}
+    cd = {{2d_solution_output__cd}}
 
     # Output area associated with each node (usefull when calculating habitat params): (F) no; (T) yes:
-    area = {{area}}
+    area = {{2d_solution_output__area}}
 
     # Output unit discharge: (F) no; (T) yes:
-    unit_discharge = {{unit_discharge}}
+    unit_discharge = {{2d_solution_output__unit_discharge}}
 
 [quasi3d_solution]
     # Calculate quasi-three-dimensional solution: (0) no; (1) yes:
-    quasi_3d = {{quasi_3d}}
+    quasi_3d = {{quasi3d_solution__quasi_3d}}
 
     # if quasi_3d == true: number of vertical nodes:
-    nz = {{nz}}
+    nz = {{quasi3d_solution__nz}}
 
     # if quasi_3d == true: use streamline curvature:
-    streamline_curv = {{streamline_curv}}
+    streamline_curv = {{quasi3d_solution__streamline_curv}}
 
     # if quasi_3d == true: minimum radius of streamline curvature:
-    min_streamline_curv = {{min_streamline_curv}}
+    min_streamline_curv = {{quasi3d_solution__min_streamline_curv}}
 
 [Grid]
     # Grid number of nodes in the streamwise direction:
-    ns = {{ns}}
+    ns = {{Grid__ns}}
 
     # Grid number of nodes in the cross-stream direction:
-    nn = {{nn}}
+    nn = {{Grid__nn}}
 
     # Grid_x:
-    x =  {{grid_x}}
+    x = {{Grid__grid_x}}
 
     # Grid_y:
-    y = {{grid_y}}
+    y = {{Grid__grid_y}}
 
     # Grid_elevation:
-    elev =  {{grid_elev}}
+    elev = {{Grid__grid_elev}}
 
     # Grid_roughness (Cd):
-    cd =  {{grid_roughness}}
+    cd = {{Grid__grid_roughness}}
 
     # Grid_znaught (m):
-    znaught =  {{grid_znaught}}
+    znaught = {{Grid__grid_znaught}}
 
     # Grid_veg_roughness (Cd):
-    vegcd = {{grid_vegcd}}
+    vegcd = {{Grid__grid_vegcd}}

--- a/meta/FaSTMECH/parameters.yaml
+++ b/meta/FaSTMECH/parameters.yaml
@@ -557,7 +557,7 @@ solution_parameters__arelax:
     units: '-'
 
 # 2d solution output
-2d_solution_output__velocitysn:
+twod_solution_output__velocitysn:
   description:
     Output velocity (streamwise and normal relative to grid) (F = no;
     T = yes)
@@ -565,14 +565,14 @@ solution_parameters__arelax:
     type: string
     default: F
     units: '-'
-2d_solution_output__shearstressxy:
+twod_solution_output__shearstressxy:
   description:
     Output boundary shear stress (F = no; T = yes)
   value:
     type: string
     default: T
     units: '-'
-2d_solution_output__shearstresssn:
+twod_solution_output__shearstresssn:
   description:
     Output boundary shear stress (streamwise and normal relative to
     grid) (F = no; T = yes)
@@ -580,14 +580,14 @@ solution_parameters__arelax:
     type: string
     default: F
     units: '-'
-2d_solution_output__cd:
+twod_solution_output__cd:
   description:
     Output drag coefficient (F = no; T = yes)
   value:
     type: string
     default: F
     units: '-'
-2d_solution_output__area:
+twod_solution_output__area:
   description:
    Output area associated with each node (useful when calculating
    habitat params) (F = no; T = yes)
@@ -595,7 +595,7 @@ solution_parameters__arelax:
     type: string
     default: F
     units: '-'
-2d_solution_output__unit_discharge:
+twod_solution_output__unit_discharge:
   description:
    Output unit discharge (F = no; T = yes)
   value:

--- a/meta/FaSTMECH/parameters.yaml
+++ b/meta/FaSTMECH/parameters.yaml
@@ -1,5 +1,5 @@
 # CGNSFile
-use_cgn:
+CGNSFile__use_cgn:
   description:
     Use the iRIC-produced CGNS file (0 = no; 1 = all; 2 = grid only)
   value:
@@ -9,7 +9,7 @@ use_cgn:
       min: 0
       max: 2
     units: '-'
-cgnsfile:
+CGNSFile__cgnsfile:
   description:
     The path to a CGNS-format file containing model run parameters for
     FaSTMECH (needed for use_cgn == 1 or 2)
@@ -19,7 +19,7 @@ cgnsfile:
     units: '-'
 
 # Discharge
-discharge_type:
+Discharge__discharge_type:
   description:
     Discharge type (0 = single valued; 1 = variable)
   value:
@@ -29,7 +29,7 @@ discharge_type:
       min: 0
       max: 1
     units: '-'
-discharge:
+Discharge__discharge:
   description:
     Single-valued discharge
   value:
@@ -39,7 +39,7 @@ discharge:
       min: 0.0E+00
       max: 1.0E+04
     units: 'm^3/s'
-vdc:
+Discharge__vdc:
   description:
     Velocity depth weighting coefficient
   value:
@@ -49,7 +49,7 @@ vdc:
       min: 1.0E-03
       max: 1.0E+03
     units: '-'
-vac:
+Discharge__vac:
   description:
     Velocity angle relative to boundary
   value:
@@ -59,14 +59,14 @@ vac:
       min: -3.6E+02
       max: 3.6E+02
     units: 'deg'
-vvalue:
+Discharge__vvalue:
   description:
     Multi-valued discharge array (needed for discharge_type == 1)
   value:
     type: string
     default: '2.5000E+00  2.5000E+00  2.5000E+00'
     units: 'm^3/s'
-vparam:
+Discharge__vparam:
   description:
     Time array for multi-valued discharge (needed for discharge_type == 1)
   value:
@@ -75,7 +75,7 @@ vparam:
     units: 's'
 
 # Stage
-stage_type:
+Stage__stage_type:
   description:
     Stage type (0 = single valued; 1 = time series; 2 = rating curve)
   value:
@@ -85,7 +85,7 @@ stage_type:
       min: 0
       max: 2
     units: '-'
-stage:
+Stage__stage:
   description:
     Single-valued stage (needed for stage_type == 0)
   value:
@@ -95,14 +95,14 @@ stage:
       min: 0.0E+00
       max: 1.0E+03
     units: 'm'
-svalue:
+Stage__svalue:
   description:
     Stage value array (needed for stage_type == 1 or 2)
   value:
     type: string
     default: '1.0000E+01  1.0000E+01  1.0000E+01'
     units: 'm'
-sparam:
+Stage__sparam:
   description:
     Stage parameter array (time (s) for stage_type == 1; discharge
     (m^3/s) for stage_type == 2)
@@ -112,7 +112,7 @@ sparam:
     units: '-'
 
 # Roughness
-roughness_type:
+Roughness__roughness_type:
   description:
     Roughness type (0 = drag coefficient; 1 = znaught)
   value:
@@ -122,7 +122,7 @@ roughness_type:
       min: 0
       max: 1
     units: '-'
-distribution_type:
+Roughness__distribution_type:
   description:
     Distribution type (0 = single-valued; 1 = spatially distributed)
   value:
@@ -132,7 +132,7 @@ distribution_type:
       min: 0
       max: 1
     units: '-'
-roughness:
+Roughness__roughness:
   description:
     Single-valued roughness (needed for roughness_type == 0)
   value:
@@ -142,7 +142,7 @@ roughness:
       min: 0.0E+00
       max: 1.0E+00
     units: '-'
-cdmin:
+Roughness__cdmin:
   description:
     Drag coefficient minimum value (needed for roughness_type == 1)
   value:
@@ -152,7 +152,7 @@ cdmin:
       min: 0.0E+00
       max: 1.0E+00
     units: '-'
-cdmax:
+Roughness__cdmax:
   description:
     Drag coefficient maximum value (needed for roughness_type == 1)
   value:
@@ -164,7 +164,7 @@ cdmax:
     units: '-'
 
 # Lateral eddy viscosity
-lev_type:
+Lateral_eddy_viscosity__lev_type:
   description:
     Lateral eddy viscosity (LEV) type (0 = single-valued; 1 =
     varialble over iteration)
@@ -175,7 +175,7 @@ lev_type:
       min: 0
       max: 1
     units: '-'
-start_iteration:
+Lateral_eddy_viscosity__start_iteration:
   description:
     Iteration to begin change (needed for lev_type == 1)
   value:
@@ -185,7 +185,7 @@ start_iteration:
       min: 0
       max: 1000000
     units: '-'
-end_iteration:
+Lateral_eddy_viscosity__end_iteration:
   description:
     Iteration to end change (needed for lev_type == 1)
   value:
@@ -195,7 +195,7 @@ end_iteration:
       min: 0
       max: 1000000
     units: '-'
-start_value:
+Lateral_eddy_viscosity__start_value:
   description:
     LEV start value (needed for lev_type == 1)
   value:
@@ -205,7 +205,7 @@ start_value:
       min: 0.0E+00
       max: 1.0E+00
     units: 'm^2/s'
-end_value:
+Lateral_eddy_viscosity__end_value:
   description:
     LEV end value (needed for lev_type == 1)
   value:
@@ -215,7 +215,7 @@ end_value:
       min: 0.0E+00
       max: 1.0E+00
     units: 'm^2/s'
-lev:
+Lateral_eddy_viscosity__lev:
   description:
     Single-valued LEV (needed for lev_type == 0)
   value:
@@ -227,7 +227,7 @@ lev:
     units: 'm^2/s'
 
 # Grid extension
-ext_numnodes:
+Grid_extension__ext_numnodes:
   description:
     Number of streamwise nodes to extend grid at downstream boundary
   value:
@@ -237,7 +237,7 @@ ext_numnodes:
       min: 0
       max: 1000000
     units: '-'
-ext_slope:
+Grid_extension__ext_slope:
   description:
     Slope to extend downstream boundary elevation (needed if ext_numnodes > 0)
   value:
@@ -247,7 +247,7 @@ ext_slope:
       min: 0.0E+00
       max: 1.0E+03
     units: 'm/m'
-down_stream_boundary:
+Grid_extension__down_stream_boundary:
   description:
     Condition of velocity at downstream boundary (0 = normal; 1 =
     force no-recirculation)
@@ -260,7 +260,7 @@ down_stream_boundary:
     units: '-'
 
 # Initial wse conditions
-init_wse_type:
+initial_wse_conditions__init_wse_type:
   description:
     Initial water-surface elevation (wse) type (0 = upstream-stage; 1
     = uniform-slope; 2 = 1d step-backwater; 3 = hot start)
@@ -271,7 +271,7 @@ init_wse_type:
       min: 0
       max: 3
     units: '-'
-upstream_stage:
+initial_wse_conditions__upstream_stage:
   description:
     Upstream stage value (needed if init_wse_type == 0)
   value:
@@ -281,7 +281,7 @@ upstream_stage:
       min: 0.0E+00
       max: 1.0E+03
     units: 'm'
-uniform_slope:
+initial_wse_conditions__uniform_slope:
   description:
     Uniform slope value (needed if init_wse_type == 1)
   value:
@@ -291,7 +291,7 @@ uniform_slope:
       min: 0.0E+00
       max: 1.0E+03
     units: 'm/m'
-oned_cd:
+initial_wse_conditions__oned_cd:
   description:
     Drag coefficient for 1D step-backward value (needed if
     init_wse_type == 2)
@@ -302,7 +302,7 @@ oned_cd:
       min: 0.0E+00
       max: 1.0E+00
     units: '-'
-hs_output:
+initial_wse_conditions__hs_output:
   description:
     Output hotstart files (0 = no; 1 = yes)
   value:
@@ -312,21 +312,21 @@ hs_output:
       min: 0
       max: 1
     units: '-'
-hs_file_path:
+initial_wse_conditions__hs_file_path:
   description:
     Path to hotstart file (needed if hs_output == 1)
   value:
     type: string
     default: ''
     units: '-'
-hs_file:
+initial_wse_conditions__hs_file:
   description:
     Hotstart filename (needed if hs_output == 1)
   value:
     type: string
     default: tmp0.d
     units: '-'
-hs_times:
+initial_wse_conditions__hs_times:
   description:
     Time to write hotstart file (needed if hs_output == 1)
   value:
@@ -335,7 +335,7 @@ hs_times:
     units: '-'
 
 # Wetting and drying
-drying_type:
+wetting_and_drying__drying_type:
   description:
     Drying type (0 = set node off; 1 = set node to drying depth)
   value:
@@ -345,7 +345,7 @@ drying_type:
       min: 0
       max: 1
     units: '-'
-drying_depth:
+wetting_and_drying__drying_depth:
   description:
     Drying depth (typically 0.0)
   value:
@@ -355,14 +355,14 @@ drying_depth:
       min: 0.0E+00
       max: 1.0E+03
     units: 'm'
-calc_rewetting:
+wetting_and_drying__calc_rewetting:
   description:
     Calculate rewetting (F = no; T = yes)
   value:
     type: string
     default: F
     units: '-'
-rewetting_depth:
+wetting_and_drying__rewetting_depth:
   description:
     Rewetting depth (typically 0.015) (needed if calc_rewetting == T)
   value:
@@ -372,7 +372,7 @@ rewetting_depth:
       min: 0.0E+00
       max: 1.0E+03
     units: 'm'
-check_rewetting_iter:
+wetting_and_drying__check_rewetting_iter:
   description:
     Iteration interval to check rewetting (needed if calc_rewetting == T)
   value:
@@ -382,7 +382,7 @@ check_rewetting_iter:
       min: 0
       max: 1000000
     units: '-'
-iter_stop_checking:
+wetting_and_drying__iter_stop_checking:
   description:
     Iteration to stop checking rewetting (needed if calc_rewetting == T)
   value:
@@ -394,7 +394,7 @@ iter_stop_checking:
     units: '-'
 
 # Solution parameters
-solution_type:
+solution_parameters__solution_type:
   description:
     Solution type (0 = constant discharge; 1 = time-varying discharge;
     3 = set at runtime)
@@ -405,7 +405,7 @@ solution_type:
       min: 0
       max: 3
     units: '-'
-num_iterations:
+solution_parameters__num_iterations:
   description:
     Number of initial iterations
   value:
@@ -415,14 +415,14 @@ num_iterations:
       min: 0
       max: 1000000
     units: '-'
-iter_solution_out:
+solution_parameters__iter_solution_out:
   description:
     Write solution during initial iteration (F = no (typical); T = yes)
   value:
     type: string
     default: F
     units: '-'
-iter_solution_inc:
+solution_parameters__iter_solution_inc:
   description:
     Iteration interval to write solution (needed if iter_sol_out == 1)
   value:
@@ -432,7 +432,7 @@ iter_solution_inc:
       min: 0
       max: 1000000
     units: '-'
-start_time:
+solution_parameters__start_time:
   description:
     Start time (needed if solution_type == 1)
   value:
@@ -442,7 +442,7 @@ start_time:
       min: 0.0E+00
       max: 1.0E+06
     units: 's'
-end_time:
+solution_parameters__end_time:
   description:
     End time (needed if solution_type == 1)
   value:
@@ -452,7 +452,7 @@ end_time:
       min: 0.0E+00
       max: 1.0E+06
     units: 's'
-time_step:
+solution_parameters__time_step:
   description:
     Time step (needed if solution_type == 1)
   value:
@@ -462,7 +462,7 @@ time_step:
       min: 0.0E+00
       max: 1.0E+06
     units: 's'
-time_step_iter:
+solution_parameters__time_step_iter:
   description:
     Iteration between time steps (needed if solution_type == 1)
   value:
@@ -472,7 +472,7 @@ time_step_iter:
       min: 0
       max: 1000000
     units: '-'
-plot_inc:
+solution_parameters__plot_inc:
   description:
     Time step increment to save solution (needed if solution_type == 1)
   value:
@@ -482,7 +482,7 @@ plot_inc:
       min: 0
       max: 1000
     units: 's'
-iter_multiplyer:
+solution_parameters__iter_multiplyer:
   description:
     Multiplyer of iteration between time steps (increases
     time_step_iter if a large number of nodes become dry or wet)
@@ -494,7 +494,7 @@ iter_multiplyer:
       min: 1
       max: 1000
     units: '-'
-debug_stop:
+solution_parameters__debug_stop:
   description:
     Stop and write solution for debugging (0 = no; 1 = yes)
   value:
@@ -504,7 +504,7 @@ debug_stop:
       min: 0
       max: 1
     units: '-'
-debug_time_step:
+solution_parameters__debug_time_step:
   description:
     Time step to stop solution (needed if debug_stop == 1)
   value:
@@ -514,7 +514,7 @@ debug_time_step:
       min: 0
       max: 1000000
     units: '-'
-debug_iteration:
+solution_parameters__debug_iteration:
   description:
     Iteration to stop solution at debug_time_step (needed if
     debug_stop == 1)
@@ -525,7 +525,7 @@ debug_iteration:
       min: 0
       max: 1000000
     units: '-'
-erelax:
+solution_parameters__erelax:
   description:
     WSE relaxation coefficient
   value:
@@ -535,7 +535,7 @@ erelax:
       min: 0.0E+00
       max: 1.0E+03
     units: '-'
-urelax:
+solution_parameters__urelax:
   description:
     Velocity relaxation coefficient
   value:
@@ -545,7 +545,7 @@ urelax:
       min: 0.0E+00
       max: 1.0E+03
     units: '-'
-arelax:
+solution_parameters__arelax:
   description:
     Slope relaxation coefficient
   value:
@@ -557,7 +557,7 @@ arelax:
     units: '-'
 
 # 2d solution output
-velocitysn:
+2d_solution_output__velocitysn:
   description:
     Output velocity (streamwise and normal relative to grid) (F = no;
     T = yes)
@@ -565,14 +565,14 @@ velocitysn:
     type: string
     default: F
     units: '-'
-shearstressxy:
+2d_solution_output__shearstressxy:
   description:
     Output boundary shear stress (F = no; T = yes)
   value:
     type: string
     default: T
     units: '-'
-shearstresssn:
+2d_solution_output__shearstresssn:
   description:
     Output boundary shear stress (streamwise and normal relative to
     grid) (F = no; T = yes)
@@ -580,14 +580,14 @@ shearstresssn:
     type: string
     default: F
     units: '-'
-cd:
+2d_solution_output__cd:
   description:
     Output drag coefficient (F = no; T = yes)
   value:
     type: string
     default: F
     units: '-'
-area:
+2d_solution_output__area:
   description:
    Output area associated with each node (useful when calculating
    habitat params) (F = no; T = yes)
@@ -595,7 +595,7 @@ area:
     type: string
     default: F
     units: '-'
-unit_discharge:
+2d_solution_output__unit_discharge:
   description:
    Output unit discharge (F = no; T = yes)
   value:
@@ -604,14 +604,14 @@ unit_discharge:
     units: '-'
 
 # Quasi-3d solution
-quasi_3d:
+quasi3d_solution__quasi_3d:
   description:
     Calculate quasi-three-dimensional solution (F = no; T = yes)
   value:
     type: string
     default: F
     units: '-'
-nz:
+quasi3d_solution__nz:
   description:
     Number of vertical nodes (needed if quasi_3d == T)
   value:
@@ -621,14 +621,14 @@ nz:
       min: 0
       max: 1000000
     units: '-'
-streamline_curv:
+quasi3d_solution__streamline_curv:
   description:
     Use streamline curvature (F = no; T = yes) (needed if quasi_3d == T)
   value:
     type: string
     default: F
     units: '-'
-min_streamline_curv:
+quasi3d_solution__min_streamline_curv:
   description:
     Minimum radius of streamline curvature (needed if quasi_3d == T)
   value:
@@ -640,7 +640,7 @@ min_streamline_curv:
     units: 'm'
 
 # Grid
-ns:
+Grid__ns:
   description:
     Grid number of nodes in the streamwise direction
   value:
@@ -650,7 +650,7 @@ ns:
       min: 0
       max: 1000000
     units: '-'
-nn:
+Grid__nn:
   description:
     Grid number of nodes in the cross-stream direction
   value:
@@ -660,42 +660,42 @@ nn:
       min: 0
       max: 1000000
     units: '-'
-grid_x:
+Grid__grid_x:
   description:
     Grid x values
   value:
     type: string
     default: '0.0E+00  1.0E+00  2.0E+00  3.0E+00  4.0E+00  5.0E+00  6.0E+00  7.0E+00  8.0E+00  9.0E+00  1.0E+01  1.1E+01  1.2E+01  1.3E+01  1.4E+01  1.5E+01  1.6E+01  1.7E+01  1.8E+01  1.9E+01  2.0E+01  2.1E+01  2.2E+01  2.3E+01  2.4E+01  2.5E+01  2.6E+01  2.7E+01  2.8E+01  2.9E+01  3.0E+01  3.1E+01  3.2E+01  3.3E+01  3.4E+01  3.5E+01  3.6E+01  3.7E+01  3.8E+01  3.9E+01  4.0E+01  4.1E+01  4.2E+01  4.3E+01  4.4E+01  4.5E+01  4.6E+01  4.7E+01  4.8E+01  4.9E+01  5.0E+01  0.0E+00  1.0E+00  2.0E+00  3.0E+00  4.0E+00  5.0E+00  6.0E+00  7.0E+00  8.0E+00  9.0E+00  1.0E+01  1.1E+01  1.2E+01  1.3E+01  1.4E+01  1.5E+01  1.6E+01  1.7E+01  1.8E+01  1.9E+01  2.0E+01  2.1E+01  2.2E+01  2.3E+01  2.4E+01  2.5E+01  2.6E+01  2.7E+01  2.8E+01  2.9E+01  3.0E+01  3.1E+01  3.2E+01  3.3E+01  3.4E+01  3.5E+01  3.6E+01  3.7E+01  3.8E+01  3.9E+01  4.0E+01  4.1E+01  4.2E+01  4.3E+01  4.4E+01  4.5E+01  4.6E+01  4.7E+01  4.8E+01  4.9E+01  5.0E+01  0.0E+00  1.0E+00  2.0E+00  3.0E+00  4.0E+00  5.0E+00  6.0E+00  7.0E+00  8.0E+00  9.0E+00  1.0E+01  1.1E+01  1.2E+01  1.3E+01  1.4E+01  1.5E+01  1.6E+01  1.7E+01  1.8E+01  1.9E+01  2.0E+01  2.1E+01  2.2E+01  2.3E+01  2.4E+01  2.5E+01  2.6E+01  2.7E+01  2.8E+01  2.9E+01  3.0E+01  3.1E+01  3.2E+01  3.3E+01  3.4E+01  3.5E+01  3.6E+01  3.7E+01  3.8E+01  3.9E+01  4.0E+01  4.1E+01  4.2E+01  4.3E+01  4.4E+01  4.5E+01  4.6E+01  4.7E+01  4.8E+01  4.9E+01  5.0E+01  0.0E+00  1.0E+00  2.0E+00  3.0E+00  4.0E+00  5.0E+00  6.0E+00  7.0E+00  8.0E+00  9.0E+00  1.0E+01  1.1E+01  1.2E+01  1.3E+01  1.4E+01  1.5E+01  1.6E+01  1.7E+01  1.8E+01  1.9E+01  2.0E+01  2.1E+01  2.2E+01  2.3E+01  2.4E+01  2.5E+01  2.6E+01  2.7E+01  2.8E+01  2.9E+01  3.0E+01  3.1E+01  3.2E+01  3.3E+01  3.4E+01  3.5E+01  3.6E+01  3.7E+01  3.8E+01  3.9E+01  4.0E+01  4.1E+01  4.2E+01  4.3E+01  4.4E+01  4.5E+01  4.6E+01  4.7E+01  4.8E+01  4.9E+01  5.0E+01  0.0E+00  1.0E+00  2.0E+00  3.0E+00  4.0E+00  5.0E+00  6.0E+00  7.0E+00  8.0E+00  9.0E+00  1.0E+01  1.1E+01  1.2E+01  1.3E+01  1.4E+01  1.5E+01  1.6E+01  1.7E+01  1.8E+01  1.9E+01  2.0E+01  2.1E+01  2.2E+01  2.3E+01  2.4E+01  2.5E+01  2.6E+01  2.7E+01  2.8E+01  2.9E+01  3.0E+01  3.1E+01  3.2E+01  3.3E+01  3.4E+01  3.5E+01  3.6E+01  3.7E+01  3.8E+01  3.9E+01  4.0E+01  4.1E+01  4.2E+01  4.3E+01  4.4E+01  4.5E+01  4.6E+01  4.7E+01  4.8E+01  4.9E+01  5.0E+01  0.0E+00  1.0E+00  2.0E+00  3.0E+00  4.0E+00  5.0E+00  6.0E+00  7.0E+00  8.0E+00  9.0E+00  1.0E+01  1.1E+01  1.2E+01  1.3E+01  1.4E+01  1.5E+01  1.6E+01  1.7E+01  1.8E+01  1.9E+01  2.0E+01  2.1E+01  2.2E+01  2.3E+01  2.4E+01  2.5E+01  2.6E+01  2.7E+01  2.8E+01  2.9E+01  3.0E+01  3.1E+01  3.2E+01  3.3E+01  3.4E+01  3.5E+01  3.6E+01  3.7E+01  3.8E+01  3.9E+01  4.0E+01  4.1E+01  4.2E+01  4.3E+01  4.4E+01  4.5E+01  4.6E+01  4.7E+01  4.8E+01  4.9E+01  5.0E+01  0.0E+00  1.0E+00  2.0E+00  3.0E+00  4.0E+00  5.0E+00  6.0E+00  7.0E+00  8.0E+00  9.0E+00  1.0E+01  1.1E+01  1.2E+01  1.3E+01  1.4E+01  1.5E+01  1.6E+01  1.7E+01  1.8E+01  1.9E+01  2.0E+01  2.1E+01  2.2E+01  2.3E+01  2.4E+01  2.5E+01  2.6E+01  2.7E+01  2.8E+01  2.9E+01  3.0E+01  3.1E+01  3.2E+01  3.3E+01  3.4E+01  3.5E+01  3.6E+01  3.7E+01  3.8E+01  3.9E+01  4.0E+01  4.1E+01  4.2E+01  4.3E+01  4.4E+01  4.5E+01  4.6E+01  4.7E+01  4.8E+01  4.9E+01  5.0E+01  0.0E+00  1.0E+00  2.0E+00  3.0E+00  4.0E+00  5.0E+00  6.0E+00  7.0E+00  8.0E+00  9.0E+00  1.0E+01  1.1E+01  1.2E+01  1.3E+01  1.4E+01  1.5E+01  1.6E+01  1.7E+01  1.8E+01  1.9E+01  2.0E+01  2.1E+01  2.2E+01  2.3E+01  2.4E+01  2.5E+01  2.6E+01  2.7E+01  2.8E+01  2.9E+01  3.0E+01  3.1E+01  3.2E+01  3.3E+01  3.4E+01  3.5E+01  3.6E+01  3.7E+01  3.8E+01  3.9E+01  4.0E+01  4.1E+01  4.2E+01  4.3E+01  4.4E+01  4.5E+01  4.6E+01  4.7E+01  4.8E+01  4.9E+01  5.0E+01  0.0E+00  1.0E+00  2.0E+00  3.0E+00  4.0E+00  5.0E+00  6.0E+00  7.0E+00  8.0E+00  9.0E+00  1.0E+01  1.1E+01  1.2E+01  1.3E+01  1.4E+01  1.5E+01  1.6E+01  1.7E+01  1.8E+01  1.9E+01  2.0E+01  2.1E+01  2.2E+01  2.3E+01  2.4E+01  2.5E+01  2.6E+01  2.7E+01  2.8E+01  2.9E+01  3.0E+01  3.1E+01  3.2E+01  3.3E+01  3.4E+01  3.5E+01  3.6E+01  3.7E+01  3.8E+01  3.9E+01  4.0E+01  4.1E+01  4.2E+01  4.3E+01  4.4E+01  4.5E+01  4.6E+01  4.7E+01  4.8E+01  4.9E+01  5.0E+01  0.0E+00  1.0E+00  2.0E+00  3.0E+00  4.0E+00  5.0E+00  6.0E+00  7.0E+00  8.0E+00  9.0E+00  1.0E+01  1.1E+01  1.2E+01  1.3E+01  1.4E+01  1.5E+01  1.6E+01  1.7E+01  1.8E+01  1.9E+01  2.0E+01  2.1E+01  2.2E+01  2.3E+01  2.4E+01  2.5E+01  2.6E+01  2.7E+01  2.8E+01  2.9E+01  3.0E+01  3.1E+01  3.2E+01  3.3E+01  3.4E+01  3.5E+01  3.6E+01  3.7E+01  3.8E+01  3.9E+01  4.0E+01  4.1E+01  4.2E+01  4.3E+01  4.4E+01  4.5E+01  4.6E+01  4.7E+01  4.8E+01  4.9E+01  5.0E+01  0.0E+00  1.0E+00  2.0E+00  3.0E+00  4.0E+00  5.0E+00  6.0E+00  7.0E+00  8.0E+00  9.0E+00  1.0E+01  1.1E+01  1.2E+01  1.3E+01  1.4E+01  1.5E+01  1.6E+01  1.7E+01  1.8E+01  1.9E+01  2.0E+01  2.1E+01  2.2E+01  2.3E+01  2.4E+01  2.5E+01  2.6E+01  2.7E+01  2.8E+01  2.9E+01  3.0E+01  3.1E+01  3.2E+01  3.3E+01  3.4E+01  3.5E+01  3.6E+01  3.7E+01  3.8E+01  3.9E+01  4.0E+01  4.1E+01  4.2E+01  4.3E+01  4.4E+01  4.5E+01  4.6E+01  4.7E+01  4.8E+01  4.9E+01  5.0E+01'
     units: 'm'
-grid_y:
+Grid__grid_y:
   description:
     Grid y values
   value:
     type: string
     default: '-5.0E+00 -5.0E+00 -5.0E+00 -5.0E+00 -5.0E+00 -5.0E+00 -5.0E+00 -5.0E+00 -5.0E+00 -5.0E+00 -5.0E+00 -5.0E+00 -5.0E+00 -5.0E+00 -5.0E+00 -5.0E+00 -5.0E+00 -5.0E+00 -5.0E+00 -5.0E+00 -5.0E+00 -5.0E+00 -5.0E+00 -5.0E+00 -5.0E+00 -5.0E+00 -5.0E+00 -5.0E+00 -5.0E+00 -5.0E+00 -5.0E+00 -5.0E+00 -5.0E+00 -5.0E+00 -5.0E+00 -5.0E+00 -5.0E+00 -5.0E+00 -5.0E+00 -5.0E+00 -5.0E+00 -5.0E+00 -5.0E+00 -5.0E+00 -5.0E+00 -5.0E+00 -5.0E+00 -5.0E+00 -5.0E+00 -5.0E+00 -5.0E+00 -4.0E+00 -4.0E+00 -4.0E+00 -4.0E+00 -4.0E+00 -4.0E+00 -4.0E+00 -4.0E+00 -4.0E+00 -4.0E+00 -4.0E+00 -4.0E+00 -4.0E+00 -4.0E+00 -4.0E+00 -4.0E+00 -4.0E+00 -4.0E+00 -4.0E+00 -4.0E+00 -4.0E+00 -4.0E+00 -4.0E+00 -4.0E+00 -4.0E+00 -4.0E+00 -4.0E+00 -4.0E+00 -4.0E+00 -4.0E+00 -4.0E+00 -4.0E+00 -4.0E+00 -4.0E+00 -4.0E+00 -4.0E+00 -4.0E+00 -4.0E+00 -4.0E+00 -4.0E+00 -4.0E+00 -4.0E+00 -4.0E+00 -4.0E+00 -4.0E+00 -4.0E+00 -4.0E+00 -4.0E+00 -4.0E+00 -4.0E+00 -4.0E+00 -3.0E+00 -3.0E+00 -3.0E+00 -3.0E+00 -3.0E+00 -3.0E+00 -3.0E+00 -3.0E+00 -3.0E+00 -3.0E+00 -3.0E+00 -3.0E+00 -3.0E+00 -3.0E+00 -3.0E+00 -3.0E+00 -3.0E+00 -3.0E+00 -3.0E+00 -3.0E+00 -3.0E+00 -3.0E+00 -3.0E+00 -3.0E+00 -3.0E+00 -3.0E+00 -3.0E+00 -3.0E+00 -3.0E+00 -3.0E+00 -3.0E+00 -3.0E+00 -3.0E+00 -3.0E+00 -3.0E+00 -3.0E+00 -3.0E+00 -3.0E+00 -3.0E+00 -3.0E+00 -3.0E+00 -3.0E+00 -3.0E+00 -3.0E+00 -3.0E+00 -3.0E+00 -3.0E+00 -3.0E+00 -3.0E+00 -3.0E+00 -3.0E+00 -2.0E+00 -2.0E+00 -2.0E+00 -2.0E+00 -2.0E+00 -2.0E+00 -2.0E+00 -2.0E+00 -2.0E+00 -2.0E+00 -2.0E+00 -2.0E+00 -2.0E+00 -2.0E+00 -2.0E+00 -2.0E+00 -2.0E+00 -2.0E+00 -2.0E+00 -2.0E+00 -2.0E+00 -2.0E+00 -2.0E+00 -2.0E+00 -2.0E+00 -2.0E+00 -2.0E+00 -2.0E+00 -2.0E+00 -2.0E+00 -2.0E+00 -2.0E+00 -2.0E+00 -2.0E+00 -2.0E+00 -2.0E+00 -2.0E+00 -2.0E+00 -2.0E+00 -2.0E+00 -2.0E+00 -2.0E+00 -2.0E+00 -2.0E+00 -2.0E+00 -2.0E+00 -2.0E+00 -2.0E+00 -2.0E+00 -2.0E+00 -2.0E+00 -1.0E+00 -1.0E+00 -1.0E+00 -1.0E+00 -1.0E+00 -1.0E+00 -1.0E+00 -1.0E+00 -1.0E+00 -1.0E+00 -1.0E+00 -1.0E+00 -1.0E+00 -1.0E+00 -1.0E+00 -1.0E+00 -1.0E+00 -1.0E+00 -1.0E+00 -1.0E+00 -1.0E+00 -1.0E+00 -1.0E+00 -1.0E+00 -1.0E+00 -1.0E+00 -1.0E+00 -1.0E+00 -1.0E+00 -1.0E+00 -1.0E+00 -1.0E+00 -1.0E+00 -1.0E+00 -1.0E+00 -1.0E+00 -1.0E+00 -1.0E+00 -1.0E+00 -1.0E+00 -1.0E+00 -1.0E+00 -1.0E+00 -1.0E+00 -1.0E+00 -1.0E+00 -1.0E+00 -1.0E+00 -1.0E+00 -1.0E+00 -1.0E+00  0.0E+00  0.0E+00  0.0E+00  0.0E+00  0.0E+00  0.0E+00  0.0E+00  0.0E+00  0.0E+00  0.0E+00  0.0E+00  0.0E+00  0.0E+00  0.0E+00  0.0E+00  0.0E+00  0.0E+00  0.0E+00  0.0E+00  0.0E+00  0.0E+00  0.0E+00  0.0E+00  0.0E+00  0.0E+00  0.0E+00  0.0E+00  0.0E+00  0.0E+00  0.0E+00  0.0E+00  0.0E+00  0.0E+00  0.0E+00  0.0E+00  0.0E+00  0.0E+00  0.0E+00  0.0E+00  0.0E+00  0.0E+00  0.0E+00  0.0E+00  0.0E+00  0.0E+00  0.0E+00  0.0E+00  0.0E+00  0.0E+00  0.0E+00  0.0E+00  1.0E+00  1.0E+00  1.0E+00  1.0E+00  1.0E+00  1.0E+00  1.0E+00  1.0E+00  1.0E+00  1.0E+00  1.0E+00  1.0E+00  1.0E+00  1.0E+00  1.0E+00  1.0E+00  1.0E+00  1.0E+00  1.0E+00  1.0E+00  1.0E+00  1.0E+00  1.0E+00  1.0E+00  1.0E+00  1.0E+00  1.0E+00  1.0E+00  1.0E+00  1.0E+00  1.0E+00  1.0E+00  1.0E+00  1.0E+00  1.0E+00  1.0E+00  1.0E+00  1.0E+00  1.0E+00  1.0E+00  1.0E+00  1.0E+00  1.0E+00  1.0E+00  1.0E+00  1.0E+00  1.0E+00  1.0E+00  1.0E+00  1.0E+00  1.0E+00  2.0E+00  2.0E+00  2.0E+00  2.0E+00  2.0E+00  2.0E+00  2.0E+00  2.0E+00  2.0E+00  2.0E+00  2.0E+00  2.0E+00  2.0E+00  2.0E+00  2.0E+00  2.0E+00  2.0E+00  2.0E+00  2.0E+00  2.0E+00  2.0E+00  2.0E+00  2.0E+00  2.0E+00  2.0E+00  2.0E+00  2.0E+00  2.0E+00  2.0E+00  2.0E+00  2.0E+00  2.0E+00  2.0E+00  2.0E+00  2.0E+00  2.0E+00  2.0E+00  2.0E+00  2.0E+00  2.0E+00  2.0E+00  2.0E+00  2.0E+00  2.0E+00  2.0E+00  2.0E+00  2.0E+00  2.0E+00  2.0E+00  2.0E+00  2.0E+00  3.0E+00  3.0E+00  3.0E+00  3.0E+00  3.0E+00  3.0E+00  3.0E+00  3.0E+00  3.0E+00  3.0E+00  3.0E+00  3.0E+00  3.0E+00  3.0E+00  3.0E+00  3.0E+00  3.0E+00  3.0E+00  3.0E+00  3.0E+00  3.0E+00  3.0E+00  3.0E+00  3.0E+00  3.0E+00  3.0E+00  3.0E+00  3.0E+00  3.0E+00  3.0E+00  3.0E+00  3.0E+00  3.0E+00  3.0E+00  3.0E+00  3.0E+00  3.0E+00  3.0E+00  3.0E+00  3.0E+00  3.0E+00  3.0E+00  3.0E+00  3.0E+00  3.0E+00  3.0E+00  3.0E+00  3.0E+00  3.0E+00  3.0E+00  3.0E+00  4.0E+00  4.0E+00  4.0E+00  4.0E+00  4.0E+00  4.0E+00  4.0E+00  4.0E+00  4.0E+00  4.0E+00  4.0E+00  4.0E+00  4.0E+00  4.0E+00  4.0E+00  4.0E+00  4.0E+00  4.0E+00  4.0E+00  4.0E+00  4.0E+00  4.0E+00  4.0E+00  4.0E+00  4.0E+00  4.0E+00  4.0E+00  4.0E+00  4.0E+00  4.0E+00  4.0E+00  4.0E+00  4.0E+00  4.0E+00  4.0E+00  4.0E+00  4.0E+00  4.0E+00  4.0E+00  4.0E+00  4.0E+00  4.0E+00  4.0E+00  4.0E+00  4.0E+00  4.0E+00  4.0E+00  4.0E+00  4.0E+00  4.0E+00  4.0E+00  5.0E+00  5.0E+00  5.0E+00  5.0E+00  5.0E+00  5.0E+00  5.0E+00  5.0E+00  5.0E+00  5.0E+00  5.0E+00  5.0E+00  5.0E+00  5.0E+00  5.0E+00  5.0E+00  5.0E+00  5.0E+00  5.0E+00  5.0E+00  5.0E+00  5.0E+00  5.0E+00  5.0E+00  5.0E+00  5.0E+00  5.0E+00  5.0E+00  5.0E+00  5.0E+00  5.0E+00  5.0E+00  5.0E+00  5.0E+00  5.0E+00  5.0E+00  5.0E+00  5.0E+00  5.0E+00  5.0E+00  5.0E+00  5.0E+00  5.0E+00  5.0E+00  5.0E+00  5.0E+00  5.0E+00  5.0E+00  5.0E+00  5.0E+00  5.0E+00'
     units: 'm'
-grid_elev:
+Grid__grid_elev:
   description:
     Grid elevation values
   value:
     type: string
     default: '1.0040E+01  1.0039E+01  1.0038E+01  1.0037E+01  1.0036E+01  1.0035E+01  1.0034E+01  1.0033E+01  1.0032E+01  1.0031E+01  1.0030E+01  1.0029E+01  1.0028E+01  1.0027E+01  1.0026E+01  1.0025E+01  1.0024E+01  1.0023E+01  1.0022E+01  1.0021E+01  1.0020E+01  1.0019E+01  1.0018E+01  1.0017E+01  1.0016E+01  1.0015E+01  1.0014E+01  1.0013E+01  1.0012E+01  1.0011E+01  1.0010E+01  1.0009E+01  1.0008E+01  1.0007E+01  1.0006E+01  1.0005E+01  1.0004E+01  1.0003E+01  1.0002E+01  1.0001E+01  1.0000E+01  9.9990E+00  9.9980E+00  9.9970E+00  9.9960E+00  9.9950E+00  9.9940E+00  9.9930E+00  9.9920E+00  9.9910E+00  9.9900E+00  9.7880E+00  9.7934E+00  9.8099E+00  9.8332E+00  9.8573E+00  9.8760E+00  9.8845E+00  9.8803E+00  9.8642E+00  9.8401E+00  9.8135E+00  9.7909E+00  9.7776E+00  9.7734E+00  9.7601E+00  9.7375E+00  9.7109E+00  9.6868E+00  9.6707E+00  9.6665E+00  9.6750E+00  9.6937E+00  9.7178E+00  9.7411E+00  9.7576E+00  9.7630E+00  9.7684E+00  9.7849E+00  9.8082E+00  9.8323E+00  9.8510E+00  9.8595E+00  9.8553E+00  9.8392E+00  9.8151E+00  9.7885E+00  9.7659E+00  9.7526E+00  9.7484E+00  9.7351E+00  9.7125E+00  9.6859E+00  9.6618E+00  9.6457E+00  9.6415E+00  9.6500E+00  9.6687E+00  9.6928E+00  9.7161E+00  9.7326E+00  9.7380E+00  9.5920E+00  9.6013E+00  9.6286E+00  9.6670E+00  9.7066E+00  9.7375E+00  9.7518E+00  9.7456E+00  9.7203E+00  9.6818E+00  9.6395E+00  9.6036E+00  9.5826E+00  9.5764E+00  9.5554E+00  9.5195E+00  9.4772E+00  9.4387E+00  9.4134E+00  9.4072E+00  9.4215E+00  9.4524E+00  9.4920E+00  9.5304E+00  9.5577E+00  9.5670E+00  9.5763E+00  9.6036E+00  9.6420E+00  9.6816E+00  9.7125E+00  9.7268E+00  9.7206E+00  9.6953E+00  9.6568E+00  9.6145E+00  9.5786E+00  9.5576E+00  9.5514E+00  9.5304E+00  9.4945E+00  9.4522E+00  9.4137E+00  9.3884E+00  9.3822E+00  9.3965E+00  9.4274E+00  9.4670E+00  9.5054E+00  9.5327E+00  9.5420E+00  9.4520E+00  9.4613E+00  9.4886E+00  9.5270E+00  9.5666E+00  9.5975E+00  9.6118E+00  9.6056E+00  9.5803E+00  9.5418E+00  9.4995E+00  9.4636E+00  9.4426E+00  9.4364E+00  9.4154E+00  9.3795E+00  9.3372E+00  9.2987E+00  9.2734E+00  9.2672E+00  9.2815E+00  9.3124E+00  9.3520E+00  9.3904E+00  9.4177E+00  9.4270E+00  9.4363E+00  9.4636E+00  9.5020E+00  9.5416E+00  9.5725E+00  9.5868E+00  9.5806E+00  9.5553E+00  9.5168E+00  9.4745E+00  9.4386E+00  9.4176E+00  9.4114E+00  9.3904E+00  9.3545E+00  9.3122E+00  9.2737E+00  9.2484E+00  9.2422E+00  9.2565E+00  9.2874E+00  9.3270E+00  9.3654E+00  9.3927E+00  9.4020E+00  9.3680E+00  9.3734E+00  9.3899E+00  9.4132E+00  9.4373E+00  9.4560E+00  9.4645E+00  9.4603E+00  9.4442E+00  9.4201E+00  9.3935E+00  9.3709E+00  9.3576E+00  9.3534E+00  9.3401E+00  9.3175E+00  9.2909E+00  9.2668E+00  9.2507E+00  9.2465E+00  9.2550E+00  9.2737E+00  9.2978E+00  9.3211E+00  9.3376E+00  9.3430E+00  9.3484E+00  9.3649E+00  9.3882E+00  9.4123E+00  9.4310E+00  9.4395E+00  9.4353E+00  9.4192E+00  9.3951E+00  9.3685E+00  9.3459E+00  9.3326E+00  9.3284E+00  9.3151E+00  9.2925E+00  9.2659E+00  9.2418E+00  9.2257E+00  9.2215E+00  9.2300E+00  9.2487E+00  9.2728E+00  9.2961E+00  9.3126E+00  9.3180E+00  9.3400E+00  9.3390E+00  9.3380E+00  9.3370E+00  9.3360E+00  9.3350E+00  9.3340E+00  9.3330E+00  9.3320E+00  9.3310E+00  9.3300E+00  9.3290E+00  9.3280E+00  9.3270E+00  9.3260E+00  9.3250E+00  9.3240E+00  9.3230E+00  9.3220E+00  9.3210E+00  9.3200E+00  9.3190E+00  9.3180E+00  9.3170E+00  9.3160E+00  9.3150E+00  9.3140E+00  9.3130E+00  9.3120E+00  9.3110E+00  9.3100E+00  9.3090E+00  9.3080E+00  9.3070E+00  9.3060E+00  9.3050E+00  9.3040E+00  9.3030E+00  9.3020E+00  9.3010E+00  9.3000E+00  9.2990E+00  9.2980E+00  9.2970E+00  9.2960E+00  9.2950E+00  9.2940E+00  9.2930E+00  9.2920E+00  9.2910E+00  9.2900E+00  9.3680E+00  9.3606E+00  9.3421E+00  9.3168E+00  9.2907E+00  9.2700E+00  9.2595E+00  9.2617E+00  9.2758E+00  9.2979E+00  9.3225E+00  9.3431E+00  9.3544E+00  9.3566E+00  9.3679E+00  9.3885E+00  9.4131E+00  9.4352E+00  9.4493E+00  9.4515E+00  9.4410E+00  9.4203E+00  9.3942E+00  9.3689E+00  9.3504E+00  9.3430E+00  9.3356E+00  9.3171E+00  9.2918E+00  9.2657E+00  9.2450E+00  9.2345E+00  9.2367E+00  9.2508E+00  9.2729E+00  9.2975E+00  9.3181E+00  9.3294E+00  9.3316E+00  9.3429E+00  9.3635E+00  9.3881E+00  9.4102E+00  9.4243E+00  9.4265E+00  9.4160E+00  9.3953E+00  9.3692E+00  9.3439E+00  9.3254E+00  9.3180E+00  9.4520E+00  9.4407E+00  9.4114E+00  9.3710E+00  9.3294E+00  9.2965E+00  9.2802E+00  9.2844E+00  9.3077E+00  9.3442E+00  9.3845E+00  9.4184E+00  9.4374E+00  9.4416E+00  9.4606E+00  9.4945E+00  9.5348E+00  9.5713E+00  9.5946E+00  9.5988E+00  9.5825E+00  9.5496E+00  9.5080E+00  9.4676E+00  9.4383E+00  9.4270E+00  9.4157E+00  9.3864E+00  9.3460E+00  9.3044E+00  9.2715E+00  9.2552E+00  9.2594E+00  9.2827E+00  9.3192E+00  9.3595E+00  9.3934E+00  9.4124E+00  9.4166E+00  9.4356E+00  9.4695E+00  9.5098E+00  9.5463E+00  9.5696E+00  9.5738E+00  9.5575E+00  9.5246E+00  9.4830E+00  9.4426E+00  9.4133E+00  9.4020E+00  9.5920E+00  9.5807E+00  9.5514E+00  9.5110E+00  9.4694E+00  9.4365E+00  9.4202E+00  9.4244E+00  9.4477E+00  9.4842E+00  9.5245E+00  9.5584E+00  9.5774E+00  9.5816E+00  9.6006E+00  9.6345E+00  9.6748E+00  9.7113E+00  9.7346E+00  9.7388E+00  9.7225E+00  9.6896E+00  9.6480E+00  9.6076E+00  9.5783E+00  9.5670E+00  9.5557E+00  9.5264E+00  9.4860E+00  9.4444E+00  9.4115E+00  9.3952E+00  9.3994E+00  9.4227E+00  9.4592E+00  9.4995E+00  9.5334E+00  9.5524E+00  9.5566E+00  9.5756E+00  9.6095E+00  9.6498E+00  9.6863E+00  9.7096E+00  9.7138E+00  9.6975E+00  9.6646E+00  9.6230E+00  9.5826E+00  9.5533E+00  9.5420E+00  9.7880E+00  9.7806E+00  9.7621E+00  9.7368E+00  9.7107E+00  9.6900E+00  9.6795E+00  9.6817E+00  9.6958E+00  9.7179E+00  9.7425E+00  9.7631E+00  9.7744E+00  9.7766E+00  9.7879E+00  9.8085E+00  9.8331E+00  9.8552E+00  9.8693E+00  9.8715E+00  9.8610E+00  9.8403E+00  9.8142E+00  9.7889E+00  9.7704E+00  9.7630E+00  9.7556E+00  9.7371E+00  9.7118E+00  9.6857E+00  9.6650E+00  9.6545E+00  9.6567E+00  9.6708E+00  9.6929E+00  9.7175E+00  9.7381E+00  9.7494E+00  9.7516E+00  9.7629E+00  9.7835E+00  9.8081E+00  9.8302E+00  9.8443E+00  9.8465E+00  9.8360E+00  9.8153E+00  9.7892E+00  9.7639E+00  9.7454E+00  9.7380E+00  1.0040E+01  1.0039E+01  1.0038E+01  1.0037E+01  1.0036E+01  1.0035E+01  1.0034E+01  1.0033E+01  1.0032E+01  1.0031E+01  1.0030E+01  1.0029E+01  1.0028E+01  1.0027E+01  1.0026E+01  1.0025E+01  1.0024E+01  1.0023E+01  1.0022E+01  1.0021E+01  1.0020E+01  1.0019E+01  1.0018E+01  1.0017E+01  1.0016E+01  1.0015E+01  1.0014E+01  1.0013E+01  1.0012E+01  1.0011E+01  1.0010E+01  1.0009E+01  1.0008E+01  1.0007E+01  1.0006E+01  1.0005E+01  1.0004E+01  1.0003E+01  1.0002E+01  1.0001E+01  1.0000E+01  9.9990E+00  9.9980E+00  9.9970E+00  9.9960E+00  9.9950E+00  9.9940E+00  9.9930E+00  9.9920E+00  9.9910E+00  9.9900E+00'
     units: 'm'
-grid_roughness:
+Grid__grid_roughness:
   description:
     Grid roughness (Cd)
   value:
     type: string
     default: '1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02'
     units: '-'
-grid_znaught:
+Grid__grid_znaught:
   description:
     Grid z0
   value:
     type: string
     default: '1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02  1.2E-02'
     units: 'm'
-grid_vegcd:
+Grid__grid_vegcd:
   description:
     Grid vegetation roughness (Cd)
   value:

--- a/meta/FaSTMECH/parameters.yaml
+++ b/meta/FaSTMECH/parameters.yaml
@@ -396,13 +396,14 @@ iter_stop_checking:
 # Solution parameters
 solution_type:
   description:
-    Solution type (0 = constant discharge; 1 = time-varying discharge)
+    Solution type (0 = constant discharge; 1 = time-varying discharge;
+    3 = set at runtime)
   value:
     type: int
     default: 0
     range:
       min: 0
-      max: 1
+      max: 3
     units: '-'
 num_iterations:
   description:


### PR DESCRIPTION
This PR updates the the componentized version of Fastmech for v0.4.2 of the model. It also includes a change to the naming of jinja template variables, and an updated Travis CI file that builds successfully.